### PR TITLE
Added compatibility for WP-CLI's media regenerate command.

### DIFF
--- a/includes/compat.php
+++ b/includes/compat.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Compatibility assistance for WordPress and Windows Azure Storage.
+ */
+
+namespace Microsoft\Azure\BlobStorage\Helpers;
+
+/**
+ * Restore original images from Azure Blob Storage when regenerating thumbnails via WP-CLI.
+ *
+ * As the Azure Blob Storage plugin offloads all media to Azure, we need to bring that media back
+ * to the local filesystem when we're regenerating thumbnails.
+ *
+ * This function very carefully determines if we're using WP-CLI's `media regenerate` command and,
+ * if so, determine whether or not the source file should be downloaded.
+ *
+ * Whether or not the file will be removed again is dependent upon the plugin settings; if the
+ * plugin has been instructed to remove media after moving it to Azure, the file we just pulled
+ * down (as well as its freshly-regenerated thumbnails) will be removed from the web server.
+ *
+ * Please note that while this executes on a WordPress filter (specifically "get_attached_file"),
+ * the value passed through the filter will *not* be modified. If, in the future, an action is
+ * added to `wp media regenerate`, it's recommended that this be rewritten to use that action
+ * instead of being a filter with side effects (albeit under a very specific use-case).
+ *
+ * @link http://wp-cli.org/commands/media/regenerate/
+ *
+ * @global $argv
+ *
+ * @param string $file          The full system filepath for the image file.
+ * @param int    $attachment_id The ID of the attachment we're resizing.
+ * @return string The unaltered $file string.
+ */
+function restore_original_image( $file, $attachment_id ) {
+	global $argv;
+
+	// Return early if we're not using WP-CLI.
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI || empty( $argv ) ) {
+		return $file;
+	}
+
+	/*
+	 * Next, ensure we're using WP-CLI's `media regenerate` command: `wp media regenerate`.
+	 *
+	 * [0] will be the path to WP-CLI.
+	 * [1] should be "media".
+	 * [2] should be "regenerate".
+	 */
+	if ( 'media' !== $argv[1] || 'regenerate' !== $argv[2] ) {
+		return $file;
+	}
+
+	// Does the file exist?
+	if ( $file && file_exists( $file ) ) {
+		return $file;
+	}
+
+	// If not, we'll need to retrieve it.
+	$url      = wp_get_attachment_url( $attachment_id );
+	$response = wp_remote_get( $url, array(
+		'timeout'  => MINUTE_IN_SECONDS,
+		'stream'   => true,
+		'filename' => $file,
+	) );
+
+	if ( is_wp_error( $response ) ) {
+		error_log( esc_html( sprintf(
+			/** Translators: %1$s is the URL, %2$s is the filepath, %3$d is the attachment ID, and %4$s the error message. */
+			__( 'Unable to download %1$s to %2$s for attachment ID %3$d: %4$s', 'windows-azure-storage' ),
+			$url,
+			$file,
+			$response->get_error_message()
+		) ) );
+
+	} elseif ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		error_log( esc_html( sprintf(
+			/** Translators: %1$d is the response code, %2$s is the URL. */
+			__( 'Received %1$d response code for %2$s', 'windows-azure-storage' ),
+			wp_remote_retrieve_response_code( $response ),
+			$url
+		) ) );
+	}
+
+	return $file;
+}
+add_filter( 'get_attached_file', __NAMESPACE__ . '\restore_original_image', 10, 2 );

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -74,6 +74,7 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 require_once MSFT_AZURE_PLUGIN_PATH . 'includes/class-windows-azure-wp-filesystem-direct.php';
 require_once MSFT_AZURE_PLUGIN_PATH . 'includes/class-windows-azure-helper.php';
+require_once MSFT_AZURE_PLUGIN_PATH . 'includes/compat.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once MSFT_AZURE_PLUGIN_PATH . 'bin/wp-cli.php';


### PR DESCRIPTION
As the plugin is often used to offload all media to Azure Blob Storage, it's necessary to pull the source files back down to the web server when we're regenerating thumbnails.

As WP-CLI doesn't expose a good way to check what command is currently being run, this filter on "get_attached_file" determines if we're in a WP-CLI context, then checks the global $argv array (which is defined when PHP is operating in the 'cli' server API). If we're indeed running `media regenerate`, the filter first checks to see if the requested file exists and, if not, download it from Azure.

There are two drawbacks to this approach:
1. This is pretty wasteful with regards to bandwidth, but that's kind of the name of the game when your WP site is offloading all of its media to a CDN/storage solution.
2. This is an abuse of the "get_attached_file" filter, as we're not doing anything to _filter_ the content, only causing side effects. Unfortunately, unless WP-CLI were to add a series of `do_action()` calls in the regeneration command, this is our most convenient point of injection.
