### PR TITLE
Add filter to allow modification of blob container properties

### DIFF
--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -807,6 +807,7 @@ class Windows_Azure_Rest_Api_Client {
 		$query_args = array(
 			'comp' => 'properties',
 		);
+
 		$properties = apply_filters( 'windows_azure_storage_blob_properties', $properties, $container, $remote_path );
 
 		$allowed_properties  = array(

--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -807,7 +807,7 @@ class Windows_Azure_Rest_Api_Client {
 		$query_args = array(
 			'comp' => 'properties',
 		);
-		$properties = apply_filters( 'azure_blob_put_blob_properties', $properties, $container, $remote_path );
+		$properties = apply_filters( 'windows_azure_storage_blob_properties', $properties, $container, $remote_path );
 
 		$allowed_properties  = array(
 			self::API_HEADER_MS_BLOB_CACHE_CONTROL,

--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -807,6 +807,7 @@ class Windows_Azure_Rest_Api_Client {
 		$query_args = array(
 			'comp' => 'properties',
 		);
+		$properties = apply_filters( 'azure_blob_put_blob_properties', $properties, $container, $remote_path );
 
 		$allowed_properties  = array(
 			self::API_HEADER_MS_BLOB_CACHE_CONTROL,

--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -807,7 +807,6 @@ class Windows_Azure_Rest_Api_Client {
 		$query_args = array(
 			'comp' => 'properties',
 		);
-
 		$properties = apply_filters( 'windows_azure_storage_blob_properties', $properties, $container, $remote_path );
 
 		$allowed_properties  = array(


### PR DESCRIPTION
Create a filter called 'azure_blob_put_blob_properties' which enables modification of Azure blob storage properties.

For example, to add HTTP Cache-Control of 1 week, add the following to your theme, etc:

```
add_filter( 'azure_blob_put_blob_properties', function ( $headers ) {
    $headers['x-ms-blob-cache-control'] = 'public, max-age=604800';
    return $headers;
} );
```

Source:
https://wordpress.org/support/topic/headers-for-uploaded-blobs/#post-8440264