### PR TITLE
Change filter name

### DIFF
--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -807,7 +807,7 @@ class Windows_Azure_Rest_Api_Client {
 		$query_args = array(
 			'comp' => 'properties',
 		);
-		$properties = apply_filters( 'azure_blob_put_blob_properties', $properties, $container, $remote_path );
+		$properties = apply_filters( 'windows_azure_storage_blob_properties', $properties, $container, $remote_path );
 
 		$allowed_properties  = array(
 			self::API_HEADER_MS_BLOB_CACHE_CONTROL,

--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -807,6 +807,7 @@ class Windows_Azure_Rest_Api_Client {
 		$query_args = array(
 			'comp' => 'properties',
 		);
+		$properties = apply_filters( 'azure_blob_put_blob_properties', $properties, $container, $remote_path );
 
 		$allowed_properties  = array(
 			self::API_HEADER_MS_BLOB_CACHE_CONTROL,


### PR DESCRIPTION
Enable filter to modify blob container properties on remote storage.  Change filter name to ' to 'windows_azure_storage_blob_properties'.