### PR TITLE
Change lookup of filepath to handle images uploaded to older posts

### DIFF
--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -383,11 +383,11 @@ function windows_azure_storage_wp_update_attachment_metadata( $data, $post_id ) 
 	if ( '/' === $upload_dir['subdir']{0} ) {
 		$upload_dir['subdir'] = substr( $upload_dir['subdir'], 1 );
 	}
-	
+
 	// Prepare blob name.
 	$relative_file_name = ( '' === $upload_dir['subdir'] ) ?
 		basename( $upload_file_name ) :
-		$upload_dir['subdir'] . '/' . basename( $upload_file_name );
+		str_replace( $upload_dir['basedir'] . '/', '', $upload_file_name );
 
 	try {
 		$post_array = wp_unslash( $_POST );


### PR DESCRIPTION
The lookup of the filepath was relying on wp_upload_dir() and would fail if you were uploading a featured image to an older post, resulting in a zero byte image. This changes the image lookup to be a partial of the get_attached_file response.