### PR TITLE
bugfix for non-image files

### DIFF
--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -389,6 +389,11 @@ function windows_azure_storage_wp_update_attachment_metadata( $data, $post_id ) 
 		basename( $upload_file_name ) :
 		str_replace( $upload_dir['basedir'] . '/', '', $upload_file_name );
 
+	// do nothing if file doesn’t exist locally
+	if ( ! Windows_Azure_Helper::file_exists( $relative_file_name ) ) {
+		return;
+	}
+	
 	try {
 		$post_array = wp_unslash( $_POST );
 		$post_array = wp_parse_args( $post_array, array(

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -389,11 +389,6 @@ function windows_azure_storage_wp_update_attachment_metadata( $data, $post_id ) 
 		basename( $upload_file_name ) :
 		str_replace( $upload_dir['basedir'] . '/', '', $upload_file_name );
 
-	// do nothing if file doesn’t exist locally
-	if ( ! Windows_Azure_Helper::file_exists( $relative_file_name ) ) {
-		return;
-	}
-	
 	try {
 		$post_array = wp_unslash( $_POST );
 		$post_array = wp_parse_args( $post_array, array(
@@ -413,12 +408,16 @@ function windows_azure_storage_wp_update_attachment_metadata( $data, $post_id ) 
 				$data['sizes'] = array();
 			}
 			set_transient( $azure_progress_key, array( 'current' => ++$current, 'total' => count( $data['sizes'] ) + 1 ), 5 * MINUTE_IN_SECONDS );
-			$result = \Windows_Azure_Helper::put_media_to_blob_storage(
-				$default_azure_storage_account_container_name,
-				$relative_file_name,
-				$relative_file_name,
-				$mime_type
-			);
+			
+			// only upload file if file exists locally
+			if (Windows_Azure_Helper::file_exists($relative_file_name)) {
+				$result = \Windows_Azure_Helper::put_media_to_blob_storage(
+					$default_azure_storage_account_container_name,
+					$relative_file_name,
+					$relative_file_name,
+					$mime_type
+				);
+			}
 
 		} catch ( Exception $e ) {
 			echo '<p>' . sprintf( __( 'Error in uploading file. Error: %s', 'windows-azure-storage' ), esc_html( $e->getMessage() ) ) . '</p><br/>';


### PR DESCRIPTION
After navigating the media library on the Wordpress instance, non-image files (such as mp3 files) would get set to 0 bytes on the Azure Storage Blob due to this code tries to manipulate the Blob afterwards. This simple addition fixes this.