### PR TITLE
Added ability to enter cache-control value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 4.1.0 / 2017-
 =================
-  *
+  * Added ability to enter Cache-Control property
 
 4.0.3 / 2017-10
 =================

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more details on Windows Azure Storage, please visit the <a href="https://azu
 ## Changelog ##
 
 ### 4.1.0 ###
-* 
+* Added ability to enter Cache-Control property
 
 ### 4.0.3 ###
 * Fixed uploading issue when year/month based folders are not used

--- a/includes/class-windows-azure-helper.php
+++ b/includes/class-windows-azure-helper.php
@@ -203,6 +203,17 @@ class Windows_Azure_Helper {
 	static public function get_cache_ttl() {
 		return (int) get_option( 'azure_browse_cache_results', 15 );
 	}
+	
+	/**
+	 * Returns cache-control.
+	 * 
+	 * @since 4.1.0
+	 * 
+	 * @return int Cache-control.
+	 */
+	static public function get_cache_control() {
+		return (int) get_option( 'azure_cache_control', 600 );
+	}
 
 	/**
 	 * Return container ACL.

--- a/includes/class-windows-azure-helper.php
+++ b/includes/class-windows-azure-helper.php
@@ -392,8 +392,10 @@ class Windows_Azure_Helper {
 		$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 		$mime_type = finfo_file( $finfo, $local_path );
 		finfo_close( $finfo );
+		
 		$rest_api_client->put_blob_properties( $container_name, $remote_path, array(
 			Windows_Azure_Rest_Api_Client::API_HEADER_MS_BLOB_CONTENT_TYPE => $mime_type,
+			Windows_Azure_Rest_Api_Client::API_HEADER_CACHE_CONTROL        => sprintf( "max-age=%d, must-revalidate", Windows_Azure_Helper::get_cache_control() ),
 		) );
 
 		return $result;
@@ -460,6 +462,7 @@ class Windows_Azure_Helper {
 
 		$rest_api_client->put_blob_properties( $container_name, $blob_name, array(
 			Windows_Azure_Rest_Api_Client::API_HEADER_MS_BLOB_CONTENT_TYPE => $mime_type,
+			Windows_Azure_Rest_Api_Client::API_HEADER_CACHE_CONTROL        => sprintf( "max-age=%d, must-revalidate", Windows_Azure_Helper::get_cache_control() ),
 		) );
 
 		return $result;

--- a/languages/windows-azure-storage.pot
+++ b/languages/windows-azure-storage.pot
@@ -4,14 +4,14 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Windows Azure Storage for WordPress 4.0.3\n"
-"POT-Creation-Date: 2017-10-19 18:02+0300\n"
+"POT-Creation-Date: 2017-11-01 21:51+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: \n"
-"X-Generator: Poedit 2.0.1\n"
+"X-Generator: Poedit 2.0.4\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_n:1;_x:1,2c;_ex:1,2c;_nx:1,2,4c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;_nx_noop:1,2,3c\n"
 "X-Poedit-SearchPath-0: .\n"
@@ -58,7 +58,7 @@ msgstr ""
 msgid "Access to WordPress filesystem has not been granted."
 msgstr ""
 
-#: includes/class-windows-azure-helper.php:370
+#: includes/class-windows-azure-helper.php:381
 #, php-format
 msgid "Uploaded file %s does not exist."
 msgstr ""
@@ -110,144 +110,152 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: windows-azure-storage-settings.php:114
+#: windows-azure-storage-settings.php:115
 msgid "Windows Azure Storage Settings"
 msgstr ""
 
-#: windows-azure-storage-settings.php:123
+#: windows-azure-storage-settings.php:124
 msgid "Store Account Name"
 msgstr ""
 
-#: windows-azure-storage-settings.php:133
+#: windows-azure-storage-settings.php:134
 msgid "Store Account Key"
 msgstr ""
 
-#: windows-azure-storage-settings.php:143
+#: windows-azure-storage-settings.php:144
 msgid "Default Storage Container"
 msgstr ""
 
-#: windows-azure-storage-settings.php:153
+#: windows-azure-storage-settings.php:154
 msgid "CNAME"
 msgstr ""
 
-#: windows-azure-storage-settings.php:163
-#: windows-azure-storage-settings.php:316
+#: windows-azure-storage-settings.php:164
+#: windows-azure-storage-settings.php:327
 msgid "Use Windows Azure Storage for default upload"
 msgstr ""
 
-#: windows-azure-storage-settings.php:173
+#: windows-azure-storage-settings.php:174
 msgid "Keep local files"
 msgstr ""
 
-#: windows-azure-storage-settings.php:183
+#: windows-azure-storage-settings.php:184
 msgid "Timeout for azure file list cache in seconds"
 msgstr ""
 
-#: windows-azure-storage-settings.php:199
+#: windows-azure-storage-settings.php:194
+msgid "Cache control in seconds"
+msgstr ""
+
+#: windows-azure-storage-settings.php:210
 msgid "If you do not have Windows Azure Storage Account, please <a href=\"http://go.microsoft.com/fwlink/?LinkID=129453\">register </a>for Windows Azure Services."
 msgstr ""
 
-#: windows-azure-storage-settings.php:214
+#: windows-azure-storage-settings.php:225
 msgid "Windows Azure Storage Account Name"
 msgstr ""
 
-#: windows-azure-storage-settings.php:228
+#: windows-azure-storage-settings.php:239
 msgid "Windows Azure Storage Account Primary Access Key"
 msgstr ""
 
-#: windows-azure-storage-settings.php:245
+#: windows-azure-storage-settings.php:256
 msgid "Default container to be used for storing media files"
 msgstr ""
 
-#: windows-azure-storage-settings.php:264
+#: windows-azure-storage-settings.php:275
 msgid "Create New Container"
 msgstr ""
 
-#: windows-azure-storage-settings.php:277
-#: windows-azure-storage-settings.php:278
+#: windows-azure-storage-settings.php:288
+#: windows-azure-storage-settings.php:289
 msgid "Name of the new container to create"
 msgstr ""
 
-#: windows-azure-storage-settings.php:277
+#: windows-azure-storage-settings.php:288
 msgid "New container name: "
 msgstr ""
 
-#: windows-azure-storage-settings.php:281
+#: windows-azure-storage-settings.php:292
 msgid "Create"
 msgstr ""
 
-#: windows-azure-storage-settings.php:297
+#: windows-azure-storage-settings.php:308
 msgid "Use CNAME instead of Windows Azure Blob URL"
 msgstr ""
 
-#: windows-azure-storage-settings.php:299
+#: windows-azure-storage-settings.php:310
 msgid "Note: Use this option if you would like to display image URLs belonging to your domain like <code>http://mydomain.com/</code> instead of <code>http://your-account-name.blob.core.windows.net/</code>."
 msgstr ""
 
-#: windows-azure-storage-settings.php:302
+#: windows-azure-storage-settings.php:313
 msgid "This CNAME must start with <code>http(s)://</code> and the administrator will have to update <abbr title=\"Domain Name System\">DNS</abbr> entries accordingly."
 msgstr ""
 
-#: windows-azure-storage-settings.php:318
+#: windows-azure-storage-settings.php:329
 msgid "Use Windows Azure Storage when uploading via WordPress' upload tab."
 msgstr ""
 
-#: windows-azure-storage-settings.php:321
+#: windows-azure-storage-settings.php:332
 msgid "Note: Uncheck this to revert back to using your own web host for storage at anytime."
 msgstr ""
 
-#: windows-azure-storage-settings.php:334
+#: windows-azure-storage-settings.php:345
 msgid "Do not delete local files after uploading them to Azure Storage."
 msgstr ""
 
-#: windows-azure-storage-settings.php:336
+#: windows-azure-storage-settings.php:347
 msgid "Keep local files after uploading them to Azure Storage."
 msgstr ""
 
-#: windows-azure-storage-settings.php:351
+#: windows-azure-storage-settings.php:362
 msgid "Browse azure file list cache TTL"
 msgstr ""
 
-#: windows-azure-storage-settings.php:355
+#: windows-azure-storage-settings.php:366
 msgid "Note: If you want to disable azure file list caching please set this value to 0."
 msgstr ""
 
-#: windows-azure-storage-settings.php:379
+#: windows-azure-storage-settings.php:386
+msgid "Setting Cache-Control on publicly accessible Windows Azure Blobs can help reduce bandwidth by preventing consumers from having to continuously download resources. Specify a relative amount of time in seconds to cache data after it was received."
+msgstr ""
+
+#: windows-azure-storage-settings.php:406
 msgid "Please specify Storage Account Name and Primary Access Key to create container."
 msgstr ""
 
-#: windows-azure-storage-settings.php:389
+#: windows-azure-storage-settings.php:416
 #, php-format
 msgid "The container <strong>%1$s</strong> successfully created. To use this container as default container, select it from the above drop down and click <strong>Save Changes</strong>."
 msgstr ""
 
-#: windows-azure-storage-settings.php:398
+#: windows-azure-storage-settings.php:425
 #, php-format
 msgid "Container creation failed, Error: %s"
 msgstr ""
 
-#: windows-azure-storage-settings.php:402
+#: windows-azure-storage-settings.php:429
 msgid "Please specify name of the container to create"
 msgstr ""
 
-#: windows-azure-storage-settings.php:404
+#: windows-azure-storage-settings.php:431
 msgid "Unable to create new container. Try again."
 msgstr ""
 
-#: windows-azure-storage-settings.php:406
+#: windows-azure-storage-settings.php:433
 msgid "You do not have permissions to create new container."
 msgstr ""
 
-#: windows-azure-storage-settings.php:408
+#: windows-azure-storage-settings.php:435
 msgid "Form validation failed. Try again."
 msgstr ""
 
-#: windows-azure-storage-settings.php:432
+#: windows-azure-storage-settings.php:459
 #, php-format
 msgid "Container creation failed. Error: %s"
 msgstr ""
 
-#: windows-azure-storage-settings.php:466
+#: windows-azure-storage-settings.php:493
 #, php-format
 msgid "Warning: The container <strong>%1$s</strong> is set to <strong>private</strong> and cannot be used. Please choose a public container as the default, or set the <strong>%1$s</strong> container to <strong>public</strong> in your Azure Storage settings."
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ For more details on Windows Azure Storage, please visit the <a href="https://azu
 == Changelog ==
 
 = 4.1.0 =
-* 
+* Added ability to enter Cache-Control property
 
 = 4.0.3 =
 * Fixed uploading issue when year/month based folders are not used

--- a/windows-azure-storage-settings.php
+++ b/windows-azure-storage-settings.php
@@ -105,6 +105,7 @@ function windows_azure_storage_plugin_register_settings() {
 	register_setting( 'windows-azure-storage-settings-group', 'azure_storage_use_for_default_upload', 'wp_validate_boolean' );
 	register_setting( 'windows-azure-storage-settings-group', 'azure_storage_keep_local_file', 'wp_validate_boolean' );
 	register_setting( 'windows-azure-storage-settings-group', 'azure_browse_cache_results', 'intval' );
+	register_setting( 'windows-azure-storage-settings-group', 'azure_cache_control', 'intval' );
 
 	/**
 	 * @since 4.0.0
@@ -182,6 +183,16 @@ function windows_azure_storage_plugin_register_settings() {
 		'azure_browse_cache_results',
 		__( 'Timeout for azure file list cache in seconds', 'windows-azure-storage' ),
 		'windows_azure_browse_cache_results',
+		'windows-azure-storage-plugin-options',
+		'windows-azure-storage-settings'
+	);
+	/**
+	 * @since 4.1.0
+	 */
+	add_settings_field(
+		'azure_cache_control',
+		__( 'Cache control in seconds', 'windows-azure-storage' ),
+		'windows_azure_cache_control',
 		'windows-azure-storage-plugin-options',
 		'windows-azure-storage-settings'
 	);
@@ -358,6 +369,22 @@ function windows_azure_browse_cache_results() {
 		?>
 	</p>
 	<?php
+}
+
+/**
+ * Displays cache-control setting.
+ *
+ * @since 4.1.0
+ *
+ * @return void
+ */
+function windows_azure_cache_control() {
+	$cache_control = Windows_Azure_Helper::get_cache_control();
+	
+	?><input type="number" name="azure_cache_control" class="regular-text" value="<?php echo esc_attr( $cache_control ); ?>">
+	<p class="field-description">
+		<?php esc_html_e( 'Setting Cache-Control on publicly accessible Windows Azure Blobs can help reduce bandwidth by preventing consumers from having to continuously download resources. Specify a relative amount of time in seconds to cache data after it was received.', 'windows-azure-storage' ); ?>
+	</p><?php	
 }
 
 /**


### PR DESCRIPTION
This request comes from wordpress.org: https://wordpress.org/support/topic/set-cache-control-property-on-blobs-before-upload/#post-9641760