### PR TITLE
Create encompassing folder for regenerated attachment, if it doesn't exist.

### DIFF
--- a/includes/compat.php
+++ b/includes/compat.php
@@ -55,6 +55,12 @@ function restore_original_image( $file, $attachment_id ) {
 		return $file;
 	}
 
+	// If the encompassing directory doesn't exist, create it so the remote_get stream doesn't fail.
+	$path = trailingslashit( pathinfo( $file )['dirname'] );
+	if ( ! file_exists( $path ) ) {
+		wp_mkdir_p( $path );
+	}
+
 	// If not, we'll need to retrieve it.
 	$url      = wp_get_attachment_url( $attachment_id );
 	$response = wp_remote_get( $url, array(

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -56,7 +56,7 @@ function restore_original_image( $file, $attachment_id ) {
 	}
 
 	// If the encompassing directory doesn't exist, create it so the remote_get stream doesn't fail.
-	$path = trailingslashit( pathinfo( $file )['dirname'] );
+	$path = pathinfo( $file )['dirname'];
 	if ( ! file_exists( $path ) ) {
 		wp_mkdir_p( $path );
 	}


### PR DESCRIPTION
The `wp_remote_get` file stream will fail if the files encompassing folder doesn't exist. This is common when an import is run without retrieving remote files. This PR adds a directory creation if it doesn't exist.