### PR TITLE
Fix no srcset for images on WP Multisite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
-4.2.1 / 2018-01
-=================
-  * Fixed no srcset issue on multisite installations
-
 4.2.0 / 2017-
 =================
   * Added ability to setup Azure settings using constants in wp-config.php file
+  * Fixed no srcset issue on multisite installations
 
 4.1.0 / 2017-11
 =================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+4.2.1 / 2018-01
+=================
+  * Fixed no srcset issue on multisite installations
+
 4.2.0 / 2017-
 =================
   * Added ability to setup Azure settings using constants in wp-config.php file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =================
   * Added ability to setup Azure settings using constants in wp-config.php file
   * Fixed no srcset issue on multisite installations
+  * Add sites/SITE_ID to the Azure Blob path for multisite installations
 
 4.1.0 / 2017-11
 =================

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use the Microsoft Azure Storage service to host your website's media files.
 **Tags:** [Microsoft](https://wordpress.org/plugins/tags/microsoft), [Microsoft Open Technologies](https://wordpress.org/plugins/tags/microsoft-open-technologies), [Microsoft Azure](https://wordpress.org/plugins/tags/windows-azure), [Microsoft Azure Storage](https://wordpress.org/plugins/tags/windows-azure-storage), [Media Files](https://wordpress.org/plugins/tags/media-files), [Upload](https://wordpress.org/plugins/tags/upload), [CDN](https://wordpress.org/plugins/tags/cdn), [blob storage](https://wordpress.org/plugins/tags/blob-storage)
 **Requires at least:** 4.0
 **Tested up to:** 4.9
-**Stable tag:** 4.2.0
+**Stable tag:** 4.2.1
 **License:** [BSD 2-Clause](http://www.opensource.org/licenses/bsd-license.php)
 
 ## Description ##
@@ -24,6 +24,10 @@ For more details on Microsoft Azure Storage, please visit the <a href="https://a
 1. Use the Settings->Microsoft Azure screen to configure the plugin.
 
 ## Changelog ##
+
+### 4.2.1 ###
+=================
+* Fixed no srcset issue on multisite installations
 
 ### 4.2.0 ###
 * Added ability to setup Azure settings using constants in wp-config.php file

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more details on Microsoft Azure Storage, please visit the <a href="https://a
 ### 4.2.0 ###
 * Added ability to setup Azure settings using constants in wp-config.php file
 * Fixed no srcset issue on multisite installations
+* Add sites/SITE_ID to the Azure Blob path for multisite installations
 
 ### 4.1.0 ###
 * Added error message when SimpleXML library is not found

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use the Microsoft Azure Storage service to host your website's media files.
 **Tags:** [Microsoft](https://wordpress.org/plugins/tags/microsoft), [Microsoft Open Technologies](https://wordpress.org/plugins/tags/microsoft-open-technologies), [Microsoft Azure](https://wordpress.org/plugins/tags/windows-azure), [Microsoft Azure Storage](https://wordpress.org/plugins/tags/windows-azure-storage), [Media Files](https://wordpress.org/plugins/tags/media-files), [Upload](https://wordpress.org/plugins/tags/upload), [CDN](https://wordpress.org/plugins/tags/cdn), [blob storage](https://wordpress.org/plugins/tags/blob-storage)
 **Requires at least:** 4.0
 **Tested up to:** 4.9
-**Stable tag:** 4.2.1
+**Stable tag:** 4.2.0
 **License:** [BSD 2-Clause](http://www.opensource.org/licenses/bsd-license.php)
 
 ## Description ##
@@ -25,12 +25,9 @@ For more details on Microsoft Azure Storage, please visit the <a href="https://a
 
 ## Changelog ##
 
-### 4.2.1 ###
-=================
-* Fixed no srcset issue on multisite installations
-
 ### 4.2.0 ###
 * Added ability to setup Azure settings using constants in wp-config.php file
+* Fixed no srcset issue on multisite installations
 
 ### 4.1.0 ###
 * Added error message when SimpleXML library is not found

--- a/includes/class-windows-azure-file-contents-provider.php
+++ b/includes/class-windows-azure-file-contents-provider.php
@@ -146,8 +146,7 @@ class Windows_Azure_File_Contents_Provider {
 			$chunk_size = self::CHUNK_SIZE;
 		}
 		if ( '/' !== $file_path[0] && ( isset( $file_path[1] ) && ':' !== $file_path[1] ) ) {
-			$upload_dir = wp_upload_dir();
-			$file_path  = trailingslashit( $upload_dir['basedir'] ) . $file_path;
+			$file_path  = trailingslashit( \Windows_Azure_Helper::get_uploads_basedir() ) . $file_path;
 		}
 		$this->_file_path     = $file_path;
 		$force_direct_access  = is_resource( $file_path );

--- a/includes/class-windows-azure-helper.php
+++ b/includes/class-windows-azure-helper.php
@@ -555,8 +555,7 @@ class Windows_Azure_Helper {
 		$result = false;
 
 		if ( WP_Filesystem() ) {
-			$upload_dir = wp_upload_dir();
-			$filename   = trailingslashit( $upload_dir['basedir'] ) . $relative_path;
+			$filename   = trailingslashit( self::get_uploads_basedir() ) . $relative_path;
 			$result     = $wp_filesystem->delete( $filename, false, 'f' );
 		}
 
@@ -579,11 +578,53 @@ class Windows_Azure_Helper {
 		$exist = false;
 
 		if ( WP_Filesystem() ) {
-			$upload_dir = wp_upload_dir();
-			$filename   = trailingslashit( $upload_dir['basedir'] ) . $relative_path;
+			$filename   = trailingslashit( self::get_uploads_basedir() ) . $relative_path;
 			$exist = $wp_filesystem->exists( $filename, false, 'f' );
 		}
 
 		return apply_filters( 'windows_azure_storage_file_exist', $exist, $relative_path );
 	}
+
+    /**
+     * Get the uploads basedir without `sites/SITE_ID` for multisite installation.
+     *
+     * @since 4.2.0
+     *
+     * @return bool
+     */
+    static public function get_uploads_basedir() {
+        $upload_dir = wp_upload_dir();
+        return preg_replace( '#\/sites\/[0-9]+#', '', $upload_dir['basedir'] );
+    }
+
+    /**
+     * Get the uploads baseurl without `sites/SITE_ID` for multisite installation.
+     *
+     * @since 4.2.0
+     *
+     * @return bool
+     */
+    static public function get_uploads_baseurl() {
+        $upload_dir = wp_upload_dir();
+        return preg_replace( '#\/sites\/[0-9]+#', '', $upload_dir['baseurl'] );
+    }
+
+    /**
+     * Get the uploads subdir and append `sites/SITE_ID` for multisite installation.
+     *
+     * @since 4.2.0
+     *
+     * @return bool
+     */
+    static public function get_uploads_subdir() {
+        $upload_dir = wp_upload_dir();
+
+        $sub_dir = ltrim( $upload_dir['subdir'], '/' );
+
+        if ( preg_match( '#sites\/[0-9]+#', $upload_dir['basedir'], $site ) ) {
+            $sub_dir = $site[0] . '/' . $sub_dir;
+        }
+
+        return $sub_dir;
+    }
 }

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -69,6 +69,7 @@ function restore_original_image( $file, $attachment_id ) {
 			__( 'Unable to download %1$s to %2$s for attachment ID %3$d: %4$s', 'windows-azure-storage' ),
 			$url,
 			$file,
+			$attachment_id,
 			$response->get_error_message()
 		) ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windows-azure-storage",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"description": "Microsoft Azure Storage for WordPress",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "windows-azure-storage",
-	"version": "4.2.1",
+	"version": "4.2.0",
 	"description": "Microsoft Azure Storage for WordPress",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"

--- a/readme.txt
+++ b/readme.txt
@@ -24,11 +24,9 @@ For more details on Microsoft Azure Storage, please visit the <a href="https://a
 
 == Changelog ==
 
-= 4.2.1 =
-* Fixed no srcset issue on multisite installations
-
 = 4.2.0 =
 * Added ability to setup Azure settings using constants in wp-config.php file
+* Fixed no srcset issue on multisite installations
 
 = 4.1.0 =
 * Added error message when SimpleXML library is not found

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,7 @@ For more details on Microsoft Azure Storage, please visit the <a href="https://a
 = 4.2.0 =
 * Added ability to setup Azure settings using constants in wp-config.php file
 * Fixed no srcset issue on multisite installations
+* Add sites/SITE_ID to the Azure Blob path for multisite installations
 
 = 4.1.0 =
 * Added error message when SimpleXML library is not found

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,9 @@ For more details on Microsoft Azure Storage, please visit the <a href="https://a
 
 == Changelog ==
 
+= 4.2.1 =
+* Fixed no srcset issue on multisite installations
+
 = 4.2.0 =
 * Added ability to setup Azure settings using constants in wp-config.php file
 

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -3,7 +3,7 @@
  * Plugin Name: Microsoft Azure Storage for WordPress
  * Plugin URI: https://wordpress.org/plugins/windows-azure-storage/
  * Description: Use the Microsoft Azure Storage service to host your website's media files.
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: 10up, Microsoft Open Technologies
  * Author URI: http://10up.com/
  * License: BSD 2-Clause
@@ -60,7 +60,7 @@
 define( 'MSFT_AZURE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'MSFT_AZURE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MSFT_AZURE_PLUGIN_LEGACY_MEDIA_URL', get_admin_url( get_current_blog_id(), 'media-upload.php' ) );
-define( 'MSFT_AZURE_PLUGIN_VERSION', '4.2.0' );
+define( 'MSFT_AZURE_PLUGIN_VERSION', '4.2.1' );
 
 require_once MSFT_AZURE_PLUGIN_PATH . 'windows-azure-storage-settings.php';
 require_once MSFT_AZURE_PLUGIN_PATH . 'windows-azure-storage-dialog.php';

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -3,7 +3,7 @@
  * Plugin Name: Microsoft Azure Storage for WordPress
  * Plugin URI: https://wordpress.org/plugins/windows-azure-storage/
  * Description: Use the Microsoft Azure Storage service to host your website's media files.
- * Version: 4.2.1
+ * Version: 4.2.0
  * Author: 10up, Microsoft Open Technologies
  * Author URI: http://10up.com/
  * License: BSD 2-Clause
@@ -60,7 +60,7 @@
 define( 'MSFT_AZURE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'MSFT_AZURE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MSFT_AZURE_PLUGIN_LEGACY_MEDIA_URL', get_admin_url( get_current_blog_id(), 'media-upload.php' ) );
-define( 'MSFT_AZURE_PLUGIN_VERSION', '4.2.1' );
+define( 'MSFT_AZURE_PLUGIN_VERSION', '4.2.0' );
 
 require_once MSFT_AZURE_PLUGIN_PATH . 'windows-azure-storage-settings.php';
 require_once MSFT_AZURE_PLUGIN_PATH . 'windows-azure-storage-dialog.php';

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -144,7 +144,6 @@ add_action( 'delete_attachment', 'windows_azure_storage_delete_attachment' );
 // Filter the 'srcset' attribute in 'the_content' introduced in WP 4.4.
 if ( function_exists( 'wp_calculate_image_srcset' ) ) {
 	add_filter( 'wp_calculate_image_srcset', 'windows_azure_storage_wp_calculate_image_srcset', 9, 5 );
-	add_filter( 'wp_calculate_image_srcset_meta', 'windows_azure_storage_image_srcset_meta', 9, 4 );
 }
 
 /**
@@ -262,13 +261,13 @@ function windows_azure_storage_new_media_object( $args ) {
 	// default azure storage container.
 	$container = \Windows_Azure_Helper::get_default_container();
 
-	$upload_dir = wp_upload_dir();
-	if ( '/' === $upload_dir['subdir'][0] ) {
-		$upload_dir['subdir'] = substr( $upload_dir['subdir'], 1 );
+	$sub_dir   = \Windows_Azure_Helper::get_uploads_subdir();
+	if ( '/' === $sub_dir[0] ) {
+        $sub_dir = substr( $sub_dir, 1 );
 	}
 
 	// Prepare blob name.
-	$blob_name = ( '' === $upload_dir['subdir'] ) ? $name : $upload_dir['subdir'] . '/' . $name;
+	$blob_name = ( '' === $sub_dir ) ? $name : $sub_dir . '/' . $name;
 
 	$blob_name = \Windows_Azure_Helper::get_unique_blob_name( $container, $blob_name );
 
@@ -376,14 +375,10 @@ function windows_azure_storage_wp_update_attachment_metadata( $data, $post_id ) 
 	$delete_local_file                            = \Windows_Azure_Helper::delete_local_file();
 	$upload_file_name                             = get_attached_file( $post_id, true );
 
-	// Get upload directory.
-	$upload_dir = wp_upload_dir();
-	$upload_dir['subdir'] = ltrim( $upload_dir['subdir'], '/' );
-
 	// Prepare blob name.
-	$relative_file_name = ( '' === $upload_dir['subdir'] ) ?
+	$relative_file_name = ( '' === \Windows_Azure_Helper::get_uploads_subdir() ) ?
 		basename( $upload_file_name ) :
-		str_replace( $upload_dir['basedir'] . '/', '', $upload_file_name );
+		str_replace( \Windows_Azure_Helper::get_uploads_basedir() . '/', '', $upload_file_name );
 
 	try {
 		$post_array = wp_unslash( $_POST );
@@ -513,11 +508,10 @@ function windows_azure_storage_wp_handle_upload_prefilter( $file ) {
 	// default azure storage container.
 	$container = \Windows_Azure_Helper::get_default_container();
 
-	$upload_dir = wp_upload_dir();
-	$upload_dir['subdir'] = ltrim( $upload_dir['subdir'], '/' );
+    $sub_dir = \Windows_Azure_Helper::get_uploads_subdir();
 
 	// Prepare blob name.
-	$blob_name = ( '' === $upload_dir['subdir'] ) ? $file['name'] : $upload_dir['subdir'] . '/' . $file['name'];
+	$blob_name = ( '' === $sub_dir ) ? $file['name'] : $sub_dir . '/' . $file['name'];
 
 	$blob_name = \Windows_Azure_Helper::get_unique_blob_name( $container, $blob_name );
 
@@ -534,10 +528,9 @@ function windows_azure_storage_wp_handle_upload_prefilter( $file ) {
  * @return array Updated metadata.
  */
 function windows_azure_storage_wp_handle_upload( $uploads ) {
-	$wp_upload_dir  = wp_upload_dir();
 	$uploads['url'] = sprintf( '%1$s/%2$s/%3$s',
 		untrailingslashit( WindowsAzureStorageUtil::get_storage_url_base() ),
-		ltrim( $wp_upload_dir['subdir'], '/' ),
+        \Windows_Azure_Helper::get_uploads_subdir(),
 		basename( $uploads['file'] )
 	);
 
@@ -553,8 +546,7 @@ function windows_azure_storage_wp_handle_upload( $uploads ) {
  * @return string Updated upload URL.
  */
 function get_updated_upload_url( $url ) {
-	$wp_upload_dir      = wp_upload_dir();
-	$upload_dir_url     = untrailingslashit( $wp_upload_dir['baseurl'] );
+	$upload_dir_url     = untrailingslashit( \Windows_Azure_Helper::get_uploads_baseurl() );
 	$storage_url_prefix = untrailingslashit( WindowsAzureStorageUtil::get_storage_url_base() );
 
 	return str_replace( $upload_dir_url, $storage_url_prefix, $url );
@@ -740,23 +732,6 @@ function windows_azure_storage_wp_calculate_image_srcset( $sources, $size_array,
 	}
 
 	return $sources;
-}
-
-/**
- * For WP multisite `srcset` is not returned for images which are uploaded using the plugin
- * This is because of a WP check for the actual image file location against the image URL
- * Multisite images file location contains the `sites/SITE_ID` in the file location and this fails the check
- * https://core.trac.wordpress.org/browser/tags/4.9.2/src/wp-includes/media.php#L1147
- *
- * This fix will remove the `sites/SITE_ID` from the actual image location
- *
- * @return array
- */
-function windows_azure_storage_image_srcset_meta( $image_meta, $size_array, $image_src, $attachment_id ) {
-	if ( is_multisite() && ! empty( $image_meta ) && ! empty( $image_meta['file'] ) ) {
-		$image_meta['file'] = preg_replace( '/sites\/[0-9]+\//', '', $image_meta['file'] );
-	}
-	return $image_meta;
 }
 
 /**


### PR DESCRIPTION
For WP multisites srcset is not returned for images which are uploaded using the plugin because of a WordPress check of the Image URL against the actual image file location on disk.