### PR TITLE
Encode filename to support special characters

### DIFF
--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -1010,6 +1010,9 @@ class Windows_Azure_Rest_Api_Client {
 			'timeout' => apply_filters( 'azure_blob_operation_timeout', self::API_REQUEST_TIMEOUT ),
 		) );
 
+		// Encode filename to support special characters
+		$path = urlencode( $path );
+
 		$endpoint_url = $this->_build_api_endpoint_url( $path );
 
 		if ( is_wp_error( $endpoint_url ) ) {


### PR DESCRIPTION
As we have been onboarding more international sites, editors have been reporting issues with special characters in filenames which causes images to 404. This small change using urlencode appears to resolve the issue but would appreciate some additional testing. 

