### PR TITLE
Update settings page links for Microzoft Azure

### DIFF
--- a/windows-azure-storage-settings.php
+++ b/windows-azure-storage-settings.php
@@ -60,7 +60,7 @@ function windows_azure_storage_plugin_settings_preamble() {
 			'windows-azure-storage'
 		); ?>
 		<br/><br/>
-		<?php echo __( 'For more details on Microsoft Azure Storage Services, please visit the <a href="http://www.microsoft.com/azure/windowsazure.mspx">Microsoft Azure Platform web-site</a>.', 'windows-azure-storage' ); ?>
+		<?php echo __( 'For more details on Microsoft Azure Storage Services, please visit the <a href="https://azure.microsoft.com/en-us/">Microsoft Azure Platform web-site</a>.', 'windows-azure-storage' ); ?>
 		<br/>
 
 		<b><?php esc_html_e( 'Plugin Web Site:', 'windows-azure-storage' ); ?></b>
@@ -208,7 +208,7 @@ function windows_azure_storage_plugin_register_settings() {
  */
 function windows_azure_storage_plugin_settings_section() {
 	?>
-	<p><?php echo __( 'If you do not have Microsoft Azure Storage Account, please <a href="http://go.microsoft.com/fwlink/?LinkID=129453">register </a>for Microsoft Azure Services.', 'windows-azure-storage' ); ?></p>
+	<p><?php echo __( 'If you do not have Microsoft Azure Storage Account, please <a href="https://azure.microsoft.com/en-us/free/">register </a>for Microsoft Azure Services.', 'windows-azure-storage' ); ?></p>
 	<?php
 }
 


### PR DESCRIPTION
Currently, if you click the link for Microsoft Azure Platform web-site as well as the one that redirects to the register page, they take you to pages that doesn't exist anymore. (see screenshots). Both pages do not show a meaningful message to users or redirect them to the new Azure Storage page.

### Screenshots: 

![microsoftazure](https://user-images.githubusercontent.com/31049169/43026302-b2edc494-8c3a-11e8-96cf-b770d2eccbc1.png)

![microsoftazure2](https://user-images.githubusercontent.com/31049169/43026303-b303b5d8-8c3a-11e8-917d-83e19c1587e3.png)

This PR updates the links for both registering and getting details about  Microsoft Azure Storage Services. 
