### PR TITLE
Fix the upload date in image metadata on back date posts

### DIFF
--- a/includes/class-windows-azure-helper.php
+++ b/includes/class-windows-azure-helper.php
@@ -598,13 +598,16 @@ class Windows_Azure_Helper {
 	 *
 	 * @static
 	 * @access public
+	 *
+	 * @param string $time Optional. Time formatted in 'yyyy/mm'. Default null.
+	 *
 	 * @return array
 	 */
-	static public function wp_upload_dir() {
+	static public function wp_upload_dir( $time = null ) {
 		static $wp_upload_dir = array();
 
 		$blog_id = get_current_blog_id();
-		if ( empty( $wp_upload_dir[ $blog_id ] ) ) {
+		if ( empty( $wp_upload_dir[ $blog_id ] ) || ! is_null( $time ) ) {
 			$dir = $upload_path = trim( get_option( 'upload_path' ) );
 			if ( empty( $upload_path ) || 'wp-content/uploads' == $upload_path ) {
 				$dir = WP_CONTENT_DIR . '/uploads';
@@ -615,12 +618,11 @@ class Windows_Azure_Helper {
 
 			$dir = rtrim( $dir, DIRECTORY_SEPARATOR );
 
-			$wp_upload_dir[ $blog_id ] = call_user_func_array( 'wp_upload_dir', func_get_args() );
+			$wp_upload_dir[ $blog_id ] = call_user_func_array( 'wp_upload_dir', array( $time ) );
 			$wp_upload_dir[ $blog_id ]['reldir'] = substr( $wp_upload_dir[ $blog_id ]['basedir'], strlen( $dir ) );
 			$wp_upload_dir[ $blog_id ]['uploads'] = $dir;
 		}
 
 		return $wp_upload_dir[ $blog_id ];
 	}
-
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
We noticed when uploading an image directly to an older post (via Gutenberg or through Media buttons on TinyMCE), thumbnails weren't loading properly and appeared broken. It became apparent that WordPress will backdate images to a post whose `post_date` is in the last month or older. When the Azure plugin swooped in, this logic wasn't factored in when the metadata was being built and would incorrectly set it for the current month. This resulted in images appearing broken as they would link to the wrong folder date.

E.g. uploading an image to November 2020, WordPress would place the image in `/uploads/2020/11/` however the Azure plugin would store metadata to `/uploads/2021/01/` if that was the current month and year.

This PR corrects that by ensuring we leverage `wp_upload_dir()` ability to change the directory in the uploads based on if we are uploading to a post and matching the date of the post. This mirrors the logic performed in `wp-admin/includes/media.php:294-299`

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
Ran tests with various posts published, drafts, old posts and brand new posts, large and small images, tested that also all image sizes are being generated as expected. Tested image uploading directly in the Media Library and pages which will always default to the current date. Tested image uploading to custom post types. Lastly, tested in single and multisite installs. 

All resulted in successfully uploaded images with the correct upload date that matches the post date or current date if Media Library or page post type.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

These appear to be relevant issues to this fix
#122 
#126 


### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
