### PR TITLE
Strengthen how `$upload_folder_path` is generated.

### DIFF
--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -400,7 +400,13 @@ function windows_azure_storage_wp_generate_attachment_metadata( $data, $post_id 
 	$file_path = ltrim( $upload_path, '/' ) . $upload_file_name;
 
 	// Upload path for remaining files.
-	$upload_folder_path = trailingslashit( ltrim( $upload_dir['reldir'] . ( ! empty( $upload_file_path_info['dirname'] ) ? '/' . $upload_file_path_info['dirname'] : '' ), '/' ) );
+	$upload_folder_path = trailingslashit(
+		sprintf(
+			'%s%s',
+			trailingslashit( ltrim( $upload_dir['reldir'], '/' ) ),
+			ltrim( ( ! empty( $upload_file_path_info['dirname'] ) ? $upload_file_path_info['dirname'] : '' ), '/' )
+		)
+	);
 
 	try {
 		$post_array = wp_unslash( $_POST );


### PR DESCRIPTION
### Description of the Change

Fixes a bug with path generation on multisite, where errant `/` entries between the `sites/#/` and date directory structure caused files to be offloaded to unnamed Azure directories, but retained the original pathing for assets, leading to broken image URLs.

This makes use of `sprintf` to generate the path for the upload folder used for the file that should be offloaded to Azure. This improves readability of an otherwise complex set of string manipulation to ensure a consistent URL pattern at all times. It also uses a few iterations of `trailingslashit` and `ltrim( $string, '/' )` to ensure no unexpected path-indicating entries are retained between variables.

### Verification Process

The changes were tested on stage sites experiencing the issues described above of double-slashed paths, and locally on single sites to ensure compatibility in both scenarios.

*Pre-patch*: Upload media, see that thumbnail remains blank, but `thumbnails` in the database are generated as expected with the correct URLs, but only the original image is seen in Azure.

*Post-patch*: Upload media, see that thumbnail renders, and checking source shows it is an intermediary size as defined by WordPress' sizes. Check Azure blob and see that all image sizes are there as expected.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#140 Initial assessment of uploads happening too early were incorrect in the issue, and during thorough troubleshooting identified to instead be caused by incorrect paths.

### Changelog Entry

Improve path generation for intermediary media sizes in multisite environments.
