### PR TITLE
Update hook, using media_buttons instead of media_buttons_context

### DIFF
--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -89,7 +89,7 @@ register_activation_hook( __FILE__, 'windows_azure_plugin_check_prerequisite' );
 
 add_action( 'plugins_loaded', 'windows_azure_storage_load_textdomain' );
 add_action( 'admin_menu', 'windows_azure_storage_plugin_menu' );
-add_filter( 'media_buttons_context', 'windows_azure_storage_media_buttons_context' );
+add_filter( 'media_buttons', 'windows_azure_storage_media_buttons_context' );
 add_action( 'load-settings_page_windows-azure-storage-plugin-options', 'windows_azure_storage_load_settings_page' );
 add_action( 'load-settings_page_windows-azure-storage-plugin-options', 'windows_azure_storage_check_container_access_policy' );
 add_action( 'wp_ajax_query-azure-attachments', 'windows_azure_storage_query_azure_attachments' );
@@ -718,13 +718,13 @@ function windows_azure_storage_dialog_browse_tab() {
  *
  * @since    1.0.0
  * @since    3.0.0 Rewrote internals to only create a single element.
- * @internal Callback for 'media_buttons_context' filter.
+ * @internal Callback for 'media_buttons' filter.
  *
  * @param string $context Media buttons context.
  *
  * @return string Media buttons context with our button appended.
  */
-function windows_azure_storage_media_buttons_context( $context ) {
+function windows_azure_storage_media_buttons( $context ) {
 	global $post_ID, $temp_ID;
 
 	$uploading_iframe_id = (int) ( 0 === $post_ID ? $temp_ID : $post_ID );

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -89,7 +89,7 @@ register_activation_hook( __FILE__, 'windows_azure_plugin_check_prerequisite' );
 
 add_action( 'plugins_loaded', 'windows_azure_storage_load_textdomain' );
 add_action( 'admin_menu', 'windows_azure_storage_plugin_menu' );
-add_filter( 'media_buttons', 'windows_azure_storage_media_buttons_context' );
+add_filter( 'media_buttons', 'windows_azure_storage_media_buttons' );
 add_action( 'load-settings_page_windows-azure-storage-plugin-options', 'windows_azure_storage_load_settings_page' );
 add_action( 'load-settings_page_windows-azure-storage-plugin-options', 'windows_azure_storage_check_container_access_policy' );
 add_action( 'wp_ajax_query-azure-attachments', 'windows_azure_storage_query_azure_attachments' );


### PR DESCRIPTION
<!--
### Requirements

Update hook
-->

### Description of the Change

`media_buttons_context`  hook has been [deprecated](https://developer.wordpress.org/reference/hooks/media_buttons_context/), using `media_buttons` action instead.  [Originally reported on WordPress.org](https://wordpress.org/support/topic/media_buttons_context-deprecated-function/#post-14893567).

### Alternate Designs

### Benefits



### Possible Drawbacks


### Verification Process

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
