### PR TITLE
Action to create issue when WordPress latest doesn't match tested up to

### DIFF
--- a/.github/workflows/wordpress-latest.yml
+++ b/.github/workflows/wordpress-latest.yml
@@ -1,5 +1,8 @@
 name: "WordPress version checker"
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     branches:
       - develop

--- a/.github/workflows/wordpress-latest.yml
+++ b/.github/workflows/wordpress-latest.yml
@@ -1,6 +1,6 @@
 name: "WordPress version checker"
 on:
-  push:
+  pull_request:
     branches:
       - develop
   schedule:

--- a/.github/workflows/wordpress-latest.yml
+++ b/.github/workflows/wordpress-latest.yml
@@ -1,0 +1,16 @@
+name: "WordPress version checker"
+on:
+  push:
+    branches:
+      - develop
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  wordpress-version-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: WordPress version checker
+        uses: skaut/wordpress-version-checker@v1.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wordpress-latest.yml
+++ b/.github/workflows/wordpress-latest.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - develop
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1'
 
 jobs:
   wordpress-version-checker:

--- a/.github/workflows/wordpress-latest.yml
+++ b/.github/workflows/wordpress-latest.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - trunk
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
### Description of the Change

Using [skaut/wordpress-version-checker](https://github.com/skaut/wordpress-version-checker) action to auto-create issue

Related to #159 (don't close until second step of verification is complete)

### Verification Process

- [x] Issue should be created if WordPress latest doesn't match plugin's "tested up to"
- [x] Duplicate issue should not be added if already exist (tested on https://github.com/10up/windows-azure-storage/pull/160/commits/fd6dbf4e9a9bfcdf939e49b9c2458891a0b7e2e7)
- [ ] Issue should be deleted after "Tested up to" does match

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added - GitHub action to auto-create issue if WordPress latest doesn't match plugin's "tested up to"
<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
