### PR TITLE
Fix PHP 8.1 Deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more details on configuring a Microsoft Azure Storage account and on using t
 
 ## Requirements
 
-* PHP 5.6+
+* PHP 7.4+
 * [WordPress](http://wordpress.org/) 4.0+
 
 ## Installation

--- a/includes/class-windows-azure-generic-list-response.php
+++ b/includes/class-windows-azure-generic-list-response.php
@@ -138,7 +138,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return mixed Can return any type.
 	 */
-	public function current() {
+	public function current(): mixed {
 		if ( ! isset( $this->_items[ $this->_position ] ) ) {
 			return null;
 		} else {
@@ -153,7 +153,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return void
 	 */
-	public function next() {
+	public function next(): void {
 		if ( ! empty( $this->_next_marker ) && ( ( count( $this->_items ) - 1 ) === $this->_position ) ) {
 			$lazy_loaded = $this->_list_items( $this->_prefix, $this->_max_results, $this->_next_marker, $this->_path );
 			if ( $lazy_loaded instanceof Windows_Azure_Generic_List_Response ) {
@@ -172,7 +172,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return mixed scalar on success, or null on failure.
 	 */
-	public function key() {
+	public function key(): mixed {
 		return $this->_position;
 	}
 
@@ -183,7 +183,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return boolean The return value will be casted to boolean and then evaluated. Returns true on success or false on failure.
 	 */
-	public function valid() {
+	public function valid(): bool {
 		return isset( $this->_items[ $this->_position ] );
 	}
 
@@ -194,7 +194,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return void
 	 */
-	public function rewind() {
+	public function rewind(): void {
 		$this->_position = 0;
 	}
 
@@ -216,7 +216,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return null|string Next portion of data marker.
 	 */
-	public function get_next_marker() {
+	public function get_next_marker(): mixed {
 		return $this->_next_marker;
 	}
 
@@ -227,7 +227,7 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return bool True or false.
 	 */
-	public function is_empty() {
+	public function is_empty(): bool {
 		return 0 === count( $this->_items );
 	}
 


### PR DESCRIPTION
### Description of the Change
Includes return type declaration for `Windows_Azure_Generic_List_Response` which implements `Iterator`
PHP 7 introduced return type declaration, so also bumps the minimum PHP version in the readme

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #168

### How to test the Change
- Create environment with PHP 8.1
- Activate plugin

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [] I have added tests to cover my change.
- [] All new and existing tests pass.
