### PR TITLE
Fix fatal errors on PHP 7.4

### DIFF
--- a/includes/class-windows-azure-generic-list-response.php
+++ b/includes/class-windows-azure-generic-list-response.php
@@ -138,7 +138,8 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return mixed Can return any type.
 	 */
-	public function current(): mixed {
+	#[\ReturnTypeWillChange]
+	public function current() {
 		if ( ! isset( $this->_items[ $this->_position ] ) ) {
 			return null;
 		} else {
@@ -172,7 +173,8 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return mixed scalar on success, or null on failure.
 	 */
-	public function key(): mixed {
+	#[\ReturnTypeWillChange]
+	public function key() {
 		return $this->_position;
 	}
 
@@ -216,7 +218,8 @@ abstract class Windows_Azure_Generic_List_Response implements Iterator {
 	 *
 	 * @return null|string Next portion of data marker.
 	 */
-	public function get_next_marker(): mixed {
+	#[\ReturnTypeWillChange]
+	public function get_next_marker() {
 		return $this->_next_marker;
 	}
 


### PR DESCRIPTION
### Description of the Change

In #169, return types were added to a few methods to address some deprecation notices showing up if you were using PHP 8.1. We also bumped our minimum PHP version to 7.4 in #170. The problem here is we used the `mixed` return type in a few places and full support for that wasn't added [until PHP 8](https://php.watch/versions/8.0/mixed-type).

This means anyone running the latest version of this plugin (v4.3.4) and still running PHP 7.4, will end up with fatal errors that cause the plugin to not function.

This PR addresses this by removing the `mixed` return type and adding the [`#[\ReturnTypeWillChange]` attribute](https://php.watch/versions/8.1/ReturnTypeWillChange) to suppress the deprecation notices for those running PHP 8.1. This should solve both the original issue as well as the newly introduced issue on PHP 7.4.

One thing to note here is once we do bump our minimum PHP version to 8.0, we'll want to remove the use of these attributes.

### How to test the Change

In an environment running PHP 7.4, go and configure the plugin. Prior to the changes here, you'll end up with a fatal error when the container settings are rendered. After this change, things should load as expected.

In an environment running PHP 8.0+, go and configure the plugin. Everything should work as expected and no deprecation warnings should be logged.

### Changelog Entry

> Fixed - Ensure things work on PHP 7.4

### Credits

Props @dkotter


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
