### PR TITLE
Bump minimum PHP version from 7.4 to 8.0

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP minimum 7.4
+    name: PHP minimum 8.0
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.0
           tools: composer:v2
           coverage: none
 
@@ -29,4 +29,4 @@ jobs:
         run: composer install
 
       - name: Run PHP Compatibility
-        run: vendor/bin/phpcs windows-azure-storage.php includes/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-
+        run: vendor/bin/phpcs windows-azure-storage.php includes/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 8.0-

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more details on configuring a Microsoft Azure Storage account and on using t
 
 ## Requirements
 
-* PHP 7.4+
+* PHP 8.0+
 * [WordPress](http://wordpress.org/ 5.7+
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4"
+    "php": ">=8.0"
   },
   "require-dev": {
     "10up/phpcs-composer": "dev-master"
   },
   "scripts": {
-    "phpcs:compat": "vendor/bin/phpcs windows-azure-storage.php includes/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-"
+    "phpcs:compat": "vendor/bin/phpcs windows-azure-storage.php includes/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 8.0-"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -522,7 +522,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      msopentech, 10up, morganestes, stevegrunwell, lpawlik, rittes
 Tags:              Microsoft, Microsoft Open Technologies, Microsoft Azure, Microsoft Azure Storage, Media Files, Upload, CDN, blob storage
 Requires at least: 5.7
 Tested up to:      6.1
-Requires PHP:      7.4
+Requires PHP:      8.0
 Stable tag:        4.3.4
 License:           BSD 2-Clause
 License URI:       http://www.opensource.org/licenses/bsd-license.php

--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -5,7 +5,7 @@
  * Description:       Use the Microsoft Azure Storage service to host your website's media files.
  * Version:           4.3.4
  * Requires at least: 5.7
- * Requires PHP:      7.4
+ * Requires PHP:      8.0
  * Author:            10up, Microsoft Open Technologies
  * Author URI:        https://10up.com/
  * License:           BSD 2-Clause
@@ -170,10 +170,10 @@ function windows_azure_storage_load_textdomain() {
 function windows_azure_plugin_check_prerequisite() {
 	global $wp_version;
 	$php_version = phpversion();
-	$php_compat  = version_compare( $php_version, '7.4.0', '>=' );
+	$php_compat  = version_compare( $php_version, '8.0.0', '>=' );
 	if ( ! $php_compat ) {
 		deactivate_plugins( plugin_basename( __FILE__ ) );
-		wp_die( __( 'Microsoft Azure Storage for WordPress requires at least PHP 7.4.0', 'windows-azure-storage' ) );
+		wp_die( __( 'Microsoft Azure Storage for WordPress requires at least PHP 8.0.0', 'windows-azure-storage' ) );
 	}
 	$wp_compat = version_compare( $wp_version, '5.7', '>=' );
 	if ( ! $wp_compat ) {


### PR DESCRIPTION
### Description of the Change

This PR bumps the minimum supported PHP version from 7.4 to 8.0. This PR is an alternative to #177, so see that issue for full details on what this solves.

### Changelog Entry

> Changed - Bump minimum PHP version from 7.4 to 8.0

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
