### PR TITLE
Remove urlencode from srcset calculation function

### DIFF
--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -879,11 +879,11 @@ function windows_azure_storage_wp_calculate_image_srcset( $sources, $size_array,
 			$img_filename = substr( $source['url'], strrpos( $source['url'], '/' ) + 1 );
 
 			if ( basename( $media_info['blob'] ) === $img_filename ) {
-				$source['url'] = esc_url( $base_url . urlencode( $media_info['blob'] ), $esc_url_protocols );
+				$source['url'] = esc_url( $base_url . $media_info['blob'], $esc_url_protocols );
 			} else {
 				foreach ( $media_info['thumbnails'] as $thumbnail ) {
 					if ( basename( $thumbnail ) === $img_filename ) {
-						$source['url'] = esc_url( $base_url . urlencode( $thumbnail ), $esc_url_protocols );
+						$source['url'] = esc_url( $base_url . $thumbnail, $esc_url_protocols );
 						break;
 					}
 				}


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This change fixes an issue with URLencoding we've seen in our sites. Blob URLs are being encoded in the `windows_azure_storage_wp_calculate_image_srcset` function which causes wrong URLs when displaying those in the browser.

![Screenshot 2023-12-11 at 09 59 02](https://github.com/10up/windows-azure-storage/assets/894708/e5044dd6-2b45-4a9e-9562-43c5198fada2)

Removing those encoding, fixes the issue and return a valid URL

### How to test the Change
- Upload an image to the blob storage
- Display the image in the frontend using `wp_get_attachment_image`. This will cause, the plugin hooks in through the `wp_calculate_image_srcset` filter

### Changelog Entry
> Fixed - Bug fix


### Credits
Props @hugosolar 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
