### PR TITLE
fix content type issue defaulting to octet-stream

### DIFF
--- a/includes/class-windows-azure-helper.php
+++ b/includes/class-windows-azure-helper.php
@@ -410,13 +410,14 @@ class Windows_Azure_Helper {
 
 		$remote_path = self::get_unique_blob_name( $container_name, $blob_name );
 
-		$result = $rest_api_client->put_blob( $container_name, $local_path, $remote_path, true );
-		if ( ! $result || is_wp_error( $result ) ) {
-			return $result;
-		}
 		$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 		$mime_type = finfo_file( $finfo, $local_path );
 		finfo_close( $finfo );
+
+		$result = $rest_api_client->put_blob( $container_name, $local_path, $remote_path, true, $mime_type );
+		if ( ! $result || is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		$rest_api_client->put_blob_properties( $container_name, $remote_path, array(
 			Windows_Azure_Rest_Api_Client::API_HEADER_MS_BLOB_CONTENT_TYPE => $mime_type,
@@ -479,7 +480,7 @@ class Windows_Azure_Helper {
 		list( $account_name, $account_key ) = self::get_api_credentials( $account_name, $account_key );
 		$rest_api_client = new Windows_Azure_Rest_Api_Client( $account_name, $account_key );
 
-		$result = $rest_api_client->put_blob( $container_name, $local_path, $blob_name );
+		$result = $rest_api_client->put_blob( $container_name, $local_path, $blob_name, false, $mime_type );
 		if ( ! $result || is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/includes/class-windows-azure-rest-api-client.php
+++ b/includes/class-windows-azure-rest-api-client.php
@@ -48,6 +48,7 @@ use MicrosoftAzure\Storage\Blob\Models\ListBlobsOptions;
 use MicrosoftAzure\Storage\Blob\Models\ListContainersOptions;
 use MicrosoftAzure\Storage\Blob\Models\SetBlobPropertiesOptions;
 use MicrosoftAzure\Storage\Blob\Models\SetBlobTierOptions;
+use MicrosoftAzure\Storage\Blob\Models\CreateBlockBlobOptions;
 
 class Windows_Azure_Rest_Api_Client {
 
@@ -985,10 +986,11 @@ class Windows_Azure_Rest_Api_Client {
 	 * @param string $local_path               Local path.
 	 * @param string $remote_path              Remote path.
 	 * @param bool   $force_direct_file_access Whether to force direct file access.
+	 * @param string $content_type             File content type
 	 *
 	 * @return bool|string|WP_Error Newly put blob URI or WP_Error|false on failure.
 	 */
-	public function put_blob( $container, $local_path, $remote_path, $force_direct_file_access = false ) {
+	public function put_blob( $container, $local_path, $remote_path, $force_direct_file_access = false, $content_type = 'application/octet-stream' ) {
 		$blobClient        = BlobRestProxy::createBlobService( $this->_connection_string );
 		$contents_provider = new Windows_Azure_File_Contents_Provider( $local_path, null );
 		$is_valid          = $contents_provider->is_valid();
@@ -998,10 +1000,12 @@ class Windows_Azure_Rest_Api_Client {
 		}
 
 		$blob_content = fopen( $contents_provider->get_file_path(), 'r' );
+		$blob_options = new CreateBlockBlobOptions();
+		$blob_options->setContentType( $content_type );
 
 		//Upload blob.
 		try {
-			$blobClient->createBlockBlob( $container, $remote_path, $blob_content );
+			$blobClient->createBlockBlob( $container, $remote_path, $blob_content, $blob_options );
 		} catch ( Exception $exception ) {
 			return new \WP_Error( $exception->getMessage() );
 		}


### PR DESCRIPTION
### Description of the Change
This PR ensures that the blob is being sent to the storage with the proper content type as we're experiencing issues with some containers defaulting the content type to `application/octet-stream`
With this fix, we're not leaving the default content type but sending the file content type directly to the `createBlockBlob()` function through the `$options` parameters

Fixes #210

### How to test the Change
- Using the plugin, upload an image to the blob container
- Using Azure storage explores, verify the proper content type is being set in the blob container

### Changelog Entry
> Fixed - Ensure we send the proper content type when creating the Block Blob in the container.

### Credits
@hugosolar 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
