### PR TITLE
Bump priority in hook to make webp conversion works

### DIFF
--- a/windows-azure-storage.php
+++ b/windows-azure-storage.php
@@ -166,10 +166,10 @@ add_action( 'media_upload_browse', 'windows_azure_browse_tab' );
 
 // Hooks for handling default file uploads.
 if ( Windows_Azure_Helper::get_use_for_default_upload() ) {
-	add_filter( 'wp_generate_attachment_metadata', 'windows_azure_storage_wp_generate_attachment_metadata', 9, 2 );
+	add_filter( 'wp_generate_attachment_metadata', 'windows_azure_storage_wp_generate_attachment_metadata', 10, 2 );
 
 	if ( Windows_Azure_Helper::delete_local_file() ) {
-		add_filter( 'wp_generate_attachment_metadata', 'windows_azure_storage_delete_local_files', 9, 2 );
+		add_filter( 'wp_generate_attachment_metadata', 'windows_azure_storage_delete_local_files', 10, 2 );
 	}
 
 	// Hook for handling blog posts via xmlrpc. This is not full proof check.


### PR DESCRIPTION
### Description of the Change
this change closes #191
I was able to investigate this issue and enabling performance lab and enable webp option causes the plugin just uploads `webp` converted images from intermediate images excluding the original.

Because of this plugin uses `wp_generate_attachment_metadata` hook to upload images to blob container, there seems to be a priority conflict with WordPress native conversion from the original image at the moment of uploading to the container. 
Increasing the hook priority to 10, make the plugin work as expected and upload the `webp` converted original image and also the original image itself which is the expected behavior (as referred by the [official documentation](https://make.wordpress.org/core/2022/03/28/enabling-webp-by-default/)).
After uploading to the blob container and checked the meta data I'm able to see the original jpeg image is kept into the meta field

```
'sources' => 
  array (
    'image/webp' => 
    array (
      'file' => 'kitty_meow-jpg.webp',
      'filesize' => 54832,
    ),
  ),
  'original_image' => 'kitty_meow.jpg',
  'url' => 'https://azurethumbs.blob.core.windows.net/playground/2024/06/kitty_meow-jpg.webp',
```

Also, the `windows_azure_storage_info` attachment meta field is keeping both images

```
array (
  'container' => 'playground',
  'blob' => '2024/06/kitty_meow-jpg.webp',
  'url' => 'https://azurethumbs.blob.core.windows.net/playground/2024/06/kitty_meow-jpg.webp',
  'thumbnails' => 
  array (
    0 => '2024/06/kitty_meow-300x200.webp',
    1 => '2024/06/kitty_meow-150x150.webp',
    2 => '2024/06/kitty_meow-768x512.webp',
    3 => '2024/06/kitty_meow.jpg',
  ),
  'version' => '4.4.2',
)
```

![Screenshot 2024-06-14 at 14 58 13](https://github.com/10up/windows-azure-storage/assets/894708/59035aef-f31e-4bc6-a9d8-70954b89c901)

### How to test the Change
- Enable Azure storage plugin
- Enable performance lab plugin
- Enable webp in the plugin settings
- Upload image
- Using Azure storage explorer checks the directory and original image and its web converted version should have been uploaded
- Check the following meta fields. both should make reference to the original image and its webp version
   - `_wp_attachment_metadata`
   - `windows_azure_storage_info`
- `_wp_attached_file` should point to the webp original version

### Changelog Entry
> Fixed - Bug fix
Fixed `webp` compatibility when uploading original images as described in #191 


### Credits
@hugosolar, @ali-awwad (for reporting it)


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
