### PR TITLE
enqueuing admin script on footer cause issue with progress

### DIFF
--- a/windows-azure-storage-dialog.php
+++ b/windows-azure-storage-dialog.php
@@ -51,7 +51,7 @@
 function windows_azure_storage_dialog_scripts( $hook_suffix ) {
 	$js_ext  = ( ! defined( 'SCRIPT_DEBUG' ) || false === SCRIPT_DEBUG ) ? '.min.js' : '.js';
 	$css_ext = ( ! defined( 'SCRIPT_DEBUG' ) || false === SCRIPT_DEBUG ) ? '.min.css' : '.css';
-	wp_enqueue_script( 'windows-azure-storage-admin', MSFT_AZURE_PLUGIN_URL . 'js/windows-azure-storage-admin' . $js_ext, array(), MSFT_AZURE_PLUGIN_VERSION, true );
+	wp_enqueue_script( 'windows-azure-storage-admin', MSFT_AZURE_PLUGIN_URL . 'js/windows-azure-storage-admin' . $js_ext, array(), MSFT_AZURE_PLUGIN_VERSION, false );
 	wp_enqueue_style( 'windows-azure-storage-style', MSFT_AZURE_PLUGIN_URL . 'css/windows-azure-storage' . $css_ext, array(), MSFT_AZURE_PLUGIN_VERSION );
 	wp_localize_script(
 		'windows-azure-storage-admin',


### PR DESCRIPTION
### Description of the Change
By testing the plugin, found an issue when enqueuing the admin script in the footer. This causes problems with showing up the upload progress in the media screen

https://drive.google.com/open?id=1-0p1hcUl6Oz5W9cfc3jfVJDekRa-YDjC

### Changelog Entry
> Fixed - Bug fix
Fixed bug with enqueuing admin script in the footer


### Credits
Props @hugosolar


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
